### PR TITLE
Update genghisapp.gemspec

### DIFF
--- a/genghisapp.gemspec
+++ b/genghisapp.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'json',             '>= 1.7.0', '< 1.9.0'
 
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'active_support'
+  gem.add_development_dependency 'activesupport'
   gem.add_development_dependency 'therubyracer'
   gem.add_development_dependency 'less'
   gem.add_development_dependency 'rainpress'


### PR DESCRIPTION
`active_support` is now called `activesupport`, this fixes the installation process
